### PR TITLE
Upgrade to GraphQL Kit 3.0 and migrate from EventLoopFutures to Async/Await

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "7ece208cd401687641c88367a00e3ea2b04311f1",
-        "version" : "1.19.0"
+        "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
+        "version" : "1.20.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent.git",
       "state" : {
-        "revision" : "dfcbeba27a576c20ff181d496f21ecd45d2c1a71",
-        "version" : "4.11.0"
+        "revision" : "223b27d04ab2b51c25503c9922eecbcdf6c12f89",
+        "version" : "4.12.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "d69efce21242ad4dba6935cc1b8d5637281604d5",
-        "version" : "1.48.5"
+        "revision" : "614d3ec27cdef50cfb9fc3cfd382b6a4d9578cff",
+        "version" : "1.49.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-sqlite-driver.git",
       "state" : {
-        "revision" : "40303a20bc39c270c8e50339ada30f9750e2a681",
-        "version" : "4.7.3"
+        "revision" : "6e3a5ff7f2cb733771a6bd71dd3a491cce79f24d",
+        "version" : "4.8.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GraphQLSwift/Graphiti.git",
       "state" : {
-        "revision" : "af903a243862c6427935677b91f67df0c21f2a71",
-        "version" : "0.26.0"
+        "revision" : "ed06f0608a72176fd572763660e7492bfb53a419",
+        "version" : "1.15.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GraphQLSwift/GraphQL.git",
       "state" : {
-        "revision" : "3cf2dbce764e7ccff8447d0b7d4634c0438449d3",
-        "version" : "2.9.2"
+        "revision" : "ec809df8cce95d6aea820f70f04067abc08080f2",
+        "version" : "2.10.3"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alexsteinerde/graphql-kit.git",
       "state" : {
-        "revision" : "73485f3ae2d200431ad6cd48e998eabc66214b64",
-        "version" : "2.4.0"
+        "revision" : "417470be5845db19d5067bfa739f640b32d031de",
+        "version" : "3.0.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "25d8170c31173c7db4ddfef473e257c3bde60783",
-        "version" : "3.30.0"
+        "revision" : "e0b35ff07601465dd9f3af19a1c23083acaae3bd",
+        "version" : "3.32.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sqlite-nio.git",
       "state" : {
-        "revision" : "1b03dafcd8b86047650925325a2bd4d20f6205fd",
-        "version" : "1.10.1"
+        "revision" : "40bf9b9fa938290176ec933540e08f39fc887f06",
+        "version" : "1.10.4"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "ce594e71e92a1610015017f83f402894df540e51",
-        "version" : "2.4.4"
+        "revision" : "e0165b53d49b413dd987526b641e05e246782685",
+        "version" : "2.5.0"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "9428f62793696d9a0cc1f26a63f63bb31da0516d",
-        "version" : "2.66.0"
+        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
+        "version" : "2.77.0"
       }
     },
     {
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a3b640d7dc567225db7c94386a6e71aded1bfa63",
-        "version" : "1.22.0"
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
       }
     },
     {
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "f9266c85189c2751589a50ea5aec72799797e471",
-        "version" : "1.3.0"
+        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
+        "version" : "1.4.0"
       }
     },
     {
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "12e9b41cc576165150cb236676fc94d997d3db5f",
-        "version" : "4.101.1"
+        "revision" : "3aeeb6fab5112fb10ce699b5a80207e5cf571c32",
+        "version" : "4.106.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0"),
 
         // 🌐 GraphQL
-        .package(url: "https://github.com/alexsteinerde/graphql-kit.git", from: "2.3.0"), // Vapor Utilities
+        .package(url: "https://github.com/alexsteinerde/graphql-kit.git", from: "3.0.0"), // Vapor Utilities
         .package(url: "https://github.com/alexsteinerde/graphiql-vapor.git", from: "2.0.0"), // Web Query Page
     ],
     targets: [

--- a/Sources/App/GraphQL/TodoResolver.swift
+++ b/Sources/App/GraphQL/TodoResolver.swift
@@ -1,9 +1,9 @@
 import Graphiti
 import Vapor
 
-final class TodoResolver {
-    func getAllUsers(request: Request, _: NoArguments) throws -> EventLoopFuture<[User]> {
-        User.query(on: request.db).all()
+struct TodoResolver {
+    func getAllUsers(request: Request, _: NoArguments) async throws -> [User] {
+        try await User.query(on: request.db).all()
     }
 
     struct CreateUserArguments: Codable {
@@ -13,24 +13,25 @@ final class TodoResolver {
     func createUser(
         request: Request,
         arguments: CreateUserArguments
-    ) throws -> EventLoopFuture<User> {
+    ) async throws -> User {
         let user = User(name: arguments.name)
-        return user.create(on: request.db).map { user }
+        try await user.create(on: request.db)
+        return user
     }
 
     struct DeleteUserArguments: Codable {
         let id: UUID
     }
 
-    func deleteUser(request: Request, arguments: DeleteUserArguments) throws -> EventLoopFuture<Bool> {
-        User.find(arguments.id, on: request.db)
-            .unwrap(or: Abort(.notFound))
-            .flatMap({ $0.delete(on: request.db) })
-            .transform(to: true)
+    func deleteUser(request: Request, arguments: DeleteUserArguments) async throws {
+        guard let user = try await User.find(arguments.id, on: request.db) else {
+            throw Abort(.notFound)
+        }
+        try await user.delete(on: request.db)
     }
 
-    func getAllTodos(request: Request, _: NoArguments) throws -> EventLoopFuture<[Todo]> {
-        Todo.query(on: request.db).all()
+    func getAllTodos(request: Request, _: NoArguments) async throws -> [Todo] {
+        try await Todo.query(on: request.db).all()
     }
 
     struct CreateTodoArguments: Codable {
@@ -38,33 +39,35 @@ final class TodoResolver {
         let userID: UUID
     }
 
-    func createTodo(request: Request, arguments: CreateTodoArguments) throws -> EventLoopFuture<Todo> {
+    func createTodo(request: Request, arguments: CreateTodoArguments) async throws -> Todo {
         let todo = Todo(title: arguments.title, userID: arguments.userID)
-        return todo.create(on: request.db).map { todo }
+        try await todo.create(on: request.db)
+        return todo
     }
     struct DeleteTodoArguments: Codable {
         let id: UUID
     }
 
-    func deleteTodo(request: Request, arguments: DeleteTodoArguments) throws -> EventLoopFuture<Bool> {
-        Todo.find(arguments.id, on: request.db)
-            .unwrap(or: Abort(.notFound))
-            .flatMap({ $0.delete(on: request.db) })
-            .transform(to: true)
+    func deleteTodo(request: Request, arguments: DeleteTodoArguments) async throws {
+        guard let todo = try await Todo.find(arguments.id, on: request.db) else {
+            throw Abort(.notFound)
+        }
+        try await todo.delete(on: request.db)
     }
     
     // Tag Resolver
-    func getAllTags(request: Request, _: NoArguments) throws -> EventLoopFuture<[Tag]> {
-        Tag.query(on: request.db).all()
+    func getAllTags(request: Request, _: NoArguments) async throws -> [Tag] {
+        try await Tag.query(on: request.db).all()
     }
     
     struct CreateTagArguments: Codable {
         let title: String
     }
 
-    func createTag(request: Request, arguments: CreateTagArguments) throws -> EventLoopFuture<Tag> {
+    func createTag(request: Request, arguments: CreateTagArguments) async throws -> Tag {
         let tag = Tag(title: arguments.title)
-        return tag.create(on: request.db).map({ tag })
+        try await tag.create(on: request.db)
+        return tag
     }
     
     struct AddTagToTodoArguments: Codable {
@@ -72,17 +75,12 @@ final class TodoResolver {
         let tagID: UUID
     }
     
-    func addTagToTodo(request: Request, arguments: AddTagToTodoArguments) throws -> EventLoopFuture<Bool> {
-        let tag = Tag.find(arguments.tagID, on: request.db)
-            .unwrap(or: Abort(.notFound))
-        let todo = Todo.find(arguments.todoID, on: request.db)
-            .unwrap(or: Abort(.notFound))
-        
-        
-        return tag.and(todo)
-            .flatMap { (tag, todo) in
-                todo.$tags.attach(tag, on: request.db)
-            }
-            .transform(to: true)
+    func addTagToTodo(request: Request, arguments: AddTagToTodoArguments) async throws {
+        async let tag = try await Tag.find(arguments.tagID, on: request.db)
+        async let todo = try await Todo.find(arguments.todoID, on: request.db)
+        guard let tag = try await tag, let todo = try await todo else {
+            throw Abort(.notFound)
+        }
+        try await todo.$tags.attach(tag, on: request.db)
     }
 }

--- a/Sources/App/GraphQL/TodoSchema.swift
+++ b/Sources/App/GraphQL/TodoSchema.swift
@@ -5,7 +5,7 @@ import Vapor
 // Definition of our GraphQL schema.
 let todoSchema = try! Schema<TodoResolver, Request> {
     Scalar(UUID.self)
-    DateScalar(formatter: ISO8601DateFormatter())
+    Scalar(Date.self)
 
     // Todo type with it's fields
     Type(Todo.self) {

--- a/Sources/App/Migrations/MigrateTodos.swift
+++ b/Sources/App/Migrations/MigrateTodos.swift
@@ -1,15 +1,15 @@
 import Fluent
 
-struct MigrateTodos: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("todos")
+struct MigrateTodos: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("todos")
             .id()
             .field("title", .string, .required)
             .field("user_id", .uuid, .required, .references("users", "id"))
             .create()
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("todos").delete()
+    func revert(on database: Database) async throws {
+        try await database.schema("todos").delete()
     }
 }

--- a/Sources/App/Migrations/MigrateUsers.swift
+++ b/Sources/App/Migrations/MigrateUsers.swift
@@ -1,8 +1,8 @@
 import Fluent
 
-struct MigrateUsers: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("users")
+struct MigrateUsers: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("users")
             .id()
             .field("name", .string, .required)
             .field("current_todo_id", .uuid, .references("todos", "id"))
@@ -10,7 +10,7 @@ struct MigrateUsers: Migration {
             .create()
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("users").delete()
+    func revert(on database: Database) async throws {
+        try await database.schema("users").delete()
     }
 }

--- a/Sources/App/Migrations/MigrationTags.swift
+++ b/Sources/App/Migrations/MigrationTags.swift
@@ -1,14 +1,14 @@
 import Fluent
 
-struct MigrateTags: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Tag.schema)
+struct MigrateTags: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Tag.schema)
             .id()
             .field("title", .string, .required)
             .create()
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Tag.schema).delete()
+    func revert(on database: Database) async throws {
+        try await database.schema(Tag.schema).delete()
     }
 }

--- a/Sources/App/Migrations/MigrationTodosTags.swift
+++ b/Sources/App/Migrations/MigrationTodosTags.swift
@@ -1,8 +1,8 @@
 import Fluent
 
-struct MigrateTodosTags: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(TodoTag.schema)
+struct MigrateTodosTags: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(TodoTag.schema)
             .id()
             .field("todo_id", .uuid, .required)
             .field("tag_id", .uuid, .required)
@@ -10,7 +10,7 @@ struct MigrateTodosTags: Migration {
             .create()
     }
     
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(TodoTag.schema).delete()
+    func revert(on database: Database) async throws {
+        try await database.schema(TodoTag.schema).delete()
     }
 }

--- a/Sources/App/Models/Tag.swift
+++ b/Sources/App/Models/Tag.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 
 /// A single entry of a Tag list.
-final class Tag: Model {
+final class Tag: Model, @unchecked Sendable {
     static let schema = "tags"
 
     /// The unique identifier for this `Tag`.

--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 
 /// A single entry of a Todo list.
-final class Todo: Model {
+final class Todo: Model, @unchecked Sendable {
     static let schema = "todos"
 
     /// The unique identifier for this `Todo`.

--- a/Sources/App/Models/TodoTag.swift
+++ b/Sources/App/Models/TodoTag.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 
 // Example of a pivot model.
-final class TodoTag: Model {
+final class TodoTag: Model, @unchecked Sendable {
     static let schema = "todo+tag"
 
     @ID(key: .id)

--- a/Sources/App/Models/User.swift
+++ b/Sources/App/Models/User.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 
 /// A single entry of a Todo list.
-final class User: Model {
+final class User: Model, @unchecked Sendable {
     static let schema = "users"
 
     /// The unique identifier for this `Todo`.


### PR DESCRIPTION
I'm new to server side swift (hence the use of a template), so I may be missing vital context here. When I tried upgrading the dependency on GraphQL Kit to their version 3.0, so that I could use the async await syntax and the AsyncMigrators, the upgrade compiles, but crashes at runtime due to the following error:

`Fatal error: 'try!' expression unexpectedly raised an error: Type "" was referenced but not defined.`

From stack traces, and breakpoint debugging, it seems that the Graphiti `typeMapReducer(typeMap:type:)` tries to map `!` to a type with an empty string for a name, which when `replaceTypeReferences(typeMap:)` is called, finds a TypeReference that hasn't been converted, and fails.

Obviously, if that's what's happening, then it's probably a bug in Graphiti. But I arrived here from trying to update this template, so I figured you might have more context than me, and opening a pull request on it might help the next person that tries to do the same thing as me.